### PR TITLE
feat/edu pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Highlights in this fork:
 - `DE-MIX` corpus wiring in `dmrst_parser/data_manager.py` (fixed splits under `data/de_mix_file_lists/`).
 - German label normalization `germanMixed_labels` in `dmrst_parser/src/corpus/relation_set.py`.
 - Utility to inventory RS3 relations: `utils/collect_rs3_relations.py`.
+ - Segmentation evaluation utility with JSON output: `utils/eval_segmentation.py` (see README_DEMIX.md).
+
+Final (segmentation reference):
+- Checkpoint: `saves/de_DE-MIX_default+base_linear_hints_40` (base + linear + sentence hints).
+- Token-boundary F1 on a 33-doc slice: Macro 0.776, Micro 0.744 (JSON under `results/seg_eval/`).
 
 To train on DE-MIX, follow `README_DEMIX.md`.
-

--- a/README_DEMIX.md
+++ b/README_DEMIX.md
@@ -114,13 +114,13 @@ python dmrst_parser/multiple_runs.py \
 ```
   - Inference with the trained run is unchanged; the model will use sentence hints internally if it was trained with them.
 
-### Recommended Segmentation Training (final)
-- Large model with linear segmenter and sentence hints (best on our data):
+### Recommended Segmentation Training (reference)
+- Segmentation-focused reference (best on our token-boundary metric): base model with linear segmenter and sentence hints.
 ```
 python dmrst_parser/multiple_runs.py \
-  --corpus DE-MIX --lang de --model_type default+linear_hints_final \
-  --transformer_name xlm-roberta-large --epochs 15 --n_runs 1 \
-  --freeze_first_n 20 --lr 1e-4 --segmenter_use_sent_boundaries 1 \
+  --corpus DE-MIX --lang de --model_type default+base_linear_hints \
+  --transformer_name xlm-roberta-base --epochs 6 --n_runs 1 \
+  --lr 1e-4 --segmenter_use_sent_boundaries 1 \
   --cuda_device 0 train
 ```
 Then segment and evaluate as shown below.
@@ -170,6 +170,15 @@ python utils/eval_segmentation.py --pred_dir data/test_output --gold_dir data/go
 ```
 - Matches files by their base name before the EDU suffix, supporting both `<name>.edus(.txt)` and `<name>_edus(.txt)` in either folder.
 - Compares right-boundary indices over whitespace tokens (ignores the final boundary). This approximates the trainer’s segmentation metric; tokenization differences can affect scores.
+ - To persist results as JSON (for comparability), add `--results_dir results/seg_eval` (auto-named by pred/gold dir and timestamp), or `--results_file` to choose an explicit path. Use `--tag` to include a run label.
+
+## Final Selection (Segmentation Reference)
+
+- Checkpoint used: `saves/de_DE-MIX_default+base_linear_hints_40` (xlm-roberta-base, linear segmenter, sentence hints, 6 epochs).
+- Token-boundary F1 on a 33-doc test slice:
+  - Macro: 0.776, Micro: 0.744
+  - JSON summary saved under `results/seg_eval/de_DE-MIX_default+base_linear_hints_40__vs__gold_test__*.json`.
+- Note: For end-to-end parsing, a large + ToNy configuration trained in short runs performed best; our current work focuses on segmentation, so we use the base+linear+hints model as the reference segmenter.
 
 ## Regression Checks
 

--- a/README_DEMIX.md
+++ b/README_DEMIX.md
@@ -113,6 +113,17 @@ python dmrst_parser/multiple_runs.py \
   --cuda_device 0 train
 ```
   - Inference with the trained run is unchanged; the model will use sentence hints internally if it was trained with them.
+
+### Recommended Segmentation Training (final)
+- Large model with linear segmenter and sentence hints (best on our data):
+```
+python dmrst_parser/multiple_runs.py \
+  --corpus DE-MIX --lang de --model_type default+linear_hints_final \
+  --transformer_name xlm-roberta-large --epochs 15 --n_runs 1 \
+  --freeze_first_n 20 --lr 1e-4 --segmenter_use_sent_boundaries 1 \
+  --cuda_device 0 train
+```
+Then segment and evaluate as shown below.
 - LUKE/MLUKE entity spans (optional):
   - If you switch to a LUKE model (`studio-ousia/mluke-*`), Trainer extracts entity spans with spaCy.
   - For German, set `--lang de` and install spaCy German as above. This can improve performance in some setups but adds compute.
@@ -146,12 +157,12 @@ pred = Predictor('saves/<run_name>', cuda_device=0)
 ```
 
 Segmentation from plain text (utility):
-- Use `utils/segment_texts.py` to turn `.txt` into `.edus.txt` with predicted EDU boundaries.
+- Use `utils/segment_texts.py` to turn `.txt` into `_edus.txt` with predicted EDU boundaries.
 ```
 python utils/segment_texts.py --model_dir saves/<run_name> \
-  --input_dir data/test_input --output_dir data/test_output --cuda_device 0
+  --input_dir data/test_input --output_dir data/test_output --cuda_device 0 [--verbose]
 ```
-Each input file produces `<output_dir>/<name>.edus.txt` with one EDU per line. Add `--dump_breaks` to also write a small JSON with debug info. Output segments are cut at predicted character offsets (no leading spaces).
+Each input file produces `<output_dir>/<name>_edus.txt` with one EDU per line. Add `--dump_breaks` to also write a small JSON with debug info. Output segments are cut at predicted character offsets (no leading spaces). Use `--verbose` to see per-file output; default is quiet with a progress bar.
 
 Segmentation evaluation (token-boundary F1):
 ```

--- a/README_DEMIX.md
+++ b/README_DEMIX.md
@@ -137,6 +137,14 @@ pred = Predictor('saves/<run_name>', cuda_device=0)
 #     logits = pred.model(...)
 ```
 
+Segmentation from plain text (utility):
+- Use `utils/segment_texts.py` to turn `.txt` into `.edus.txt` with predicted EDU boundaries.
+```
+python utils/segment_texts.py --model_dir saves/<run_name> \
+  --inputs path/to/texts/*.txt --out_dir out_edus --cuda_device 0
+```
+Each input file produces `out_edus/<name>.edus.txt` with one EDU per line.
+
 ## Regression Checks
 
 - After changes, re-run RuRSTB preparation to ensure nothing breaks existing flows:

--- a/configs/general_config.jsonnet
+++ b/configs/general_config.jsonnet
@@ -26,6 +26,7 @@ local epochs = std.extVar("epochs");
 local segmenter_dropout = std.extVar("segmenter_dropout");
 local segmenter_hidden_dim = std.extVar("segmenter_hidden_dim");
 local segmenter_type = std.extVar("segmenter_type");
+local segmenter_use_sent_boundaries = std.extVar("segmenter_use_sent_boundaries");
 local token_bilstm_hidden = std.extVar("token_bilstm_hidden");
 local transformer_name = std.extVar("transformer_name");
 local use_crf = std.extVar("use_crf");
@@ -58,6 +59,7 @@ local use_amp = std.extVar("use_amp");
             "type": segmenter_type,
             "use_crf": use_crf,
             "use_log_crf": use_log_crf,
+            "use_sent_boundaries": segmenter_use_sent_boundaries,
             "hidden_dim": segmenter_hidden_dim,
             "lstm_dropout": 0.2,
             "lstm_num_layers": 1,

--- a/dmrst_parser/data_manager.py
+++ b/dmrst_parser/data_manager.py
@@ -16,7 +16,7 @@ from dmrst_parser.src.parser.data import Data
 from dmrst_parser.src.parser.data import RelationTableGUM, RelationTableRSTDT, RelationTableRuRSTB
 
 random.seed(42)
-nltk.download('punkt')
+nltk.download('punkt', quiet=True)
 
 
 class ParserInput:

--- a/dmrst_parser/multiple_runs.py
+++ b/dmrst_parser/multiple_runs.py
@@ -40,6 +40,7 @@ class MultipleRunnerGeneral:
                  epochs: int = 100,
                  lr: float = 1e-4,
                  use_amp: bool = False,
+                 segmenter_use_sent_boundaries: bool = False,
                  ):
         """
         :param corpus: (str)  - 'GUM' or 'RST-DT'
@@ -65,6 +66,7 @@ class MultipleRunnerGeneral:
         self.epochs = epochs
         self.lr = lr
         self.use_amp = use_amp
+        self.segmenter_use_sent_boundaries = segmenter_use_sent_boundaries
 
     def _general_parameters(self):
         # Auto-set embedding size to match common XLM-R variants if user didn't change default
@@ -141,6 +143,7 @@ class MultipleRunnerGeneral:
             'segmenter_type': 'linear',
             'segmenter_hidden_dim': overrides['hidden_size'],
             'segmenter_dropout': 0.4,
+            'segmenter_use_sent_boundaries': 'true' if self.segmenter_use_sent_boundaries else 'false',
             'lstm_bidirectional': 'true',
             'if_edu_start_loss': 'true',
             'edu_encoding_kind': 'avg',

--- a/dmrst_parser/predictor.py
+++ b/dmrst_parser/predictor.py
@@ -92,6 +92,11 @@ class Predictor:
         if 'if_edu_start_loss' in self.config['model']['segmenter']:
             config['segmenter_if_edu_start_loss'] = str2bool(self.config['model']['segmenter'].get('if_edu_start_loss'))
 
+        # Ensure sentence-boundary hints toggle is respected at inference
+        if 'use_sent_boundaries' in self.config['model']['segmenter']:
+            config['segmenter_use_sent_boundaries'] = str2bool(
+                self.config['model']['segmenter'].get('use_sent_boundaries'))
+
         if 'edu_encoding_kind' in self.config['model']:
             config['edu_encoding_kind'] = self.config['model'].get('edu_encoding_kind')
 

--- a/dmrst_parser/trainer.py
+++ b/dmrst_parser/trainer.py
@@ -168,6 +168,11 @@ class Trainer:
             elif self.data_lang == 'de':
                 self._spacy = spacy.load("de_core_news_lg")  # python -m spacy download de_core_news_lg
 
+        # If sentence boundaries are requested for the segmenter, ensure spaCy is loaded for German
+        if self.model_segmenter_use_sent_boundaries and self.data_lang == 'de' and not hasattr(self, '_spacy'):
+            # Requires: python -m spacy download de_core_news_lg
+            self._spacy = spacy.load("de_core_news_lg")
+
         self._set_random_seeds()
         self._load_data()
         self._setup_model()

--- a/utils/eval_segmentation.py
+++ b/utils/eval_segmentation.py
@@ -1,0 +1,120 @@
+import argparse
+import glob
+import os
+import re
+from pathlib import Path
+
+
+def load_boundaries_from_edus_file(path: str):
+    """Reads an .edus or .edus.txt file and returns cumulative right-boundary indices over whitespace tokens.
+
+    Returns:
+        total_tokens (int), boundaries (set[int]) excluding the final boundary.
+    """
+    with open(path, 'r', encoding='utf-8') as f:
+        lines = [ln.rstrip('\n') for ln in f]
+
+    cum = 0
+    boundaries = []
+    for ln in lines:
+        # Tokenize on whitespace; punctuation remains attached which matches our segmentation outputs
+        n = len(ln.split()) if ln else 0
+        if n == 0:
+            continue
+        cum += n
+        boundaries.append(cum - 1)
+
+    # Remove final boundary (end of document) for standard segmentation metrics
+    if boundaries:
+        boundaries = boundaries[:-1]
+    return cum, set(boundaries)
+
+
+def f1_from_sets(pred: set, gold: set):
+    tp = len(pred & gold)
+    p = len(pred)
+    g = len(gold)
+    prec = tp / p if p > 0 else 0.0
+    rec = tp / g if g > 0 else 0.0
+    if prec + rec == 0:
+        f1 = 0.0
+    else:
+        f1 = 2 * prec * rec / (prec + rec)
+    return prec, rec, f1, tp, p, g
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Evaluate segmentation F1 by comparing predicted EDUs to gold EDUs.')
+    ap.add_argument('--pred_dir', required=True, help='Directory with predicted files (e.g., <name>.edus.txt or <name>_edus.txt)')
+    ap.add_argument('--gold_dir', required=True, help='Directory with gold files (e.g., <name>.edus or <name>_edus)')
+    args = ap.parse_args()
+
+    def collect_map(folder):
+        # Match names like: <name>.edus.txt, <name>.edus, <name>_edus.txt, <name>_edus
+        rx = re.compile(r"^(?P<base>.+?)(?:[._]edus)(?:\.txt)?$", re.IGNORECASE)
+        mapping = {}
+        for fp in sorted(glob.glob(os.path.join(folder, '*'))):
+            if not os.path.isfile(fp):
+                continue
+            m = rx.match(os.path.basename(fp))
+            if not m:
+                continue
+            base = m.group('base')
+            mapping.setdefault(base, fp)
+        return mapping
+
+    pred_map = collect_map(args.pred_dir)
+    gold_map = collect_map(args.gold_dir)
+
+    if not pred_map:
+        raise SystemExit(f'No prediction EDU files found in {args.pred_dir}')
+
+    macro_prec = []
+    macro_rec = []
+    macro_f1 = []
+    tp_sum = p_sum = g_sum = 0
+
+    missing = []
+    per_file = []
+
+    for name, pp in sorted(pred_map.items()):
+        gold_path = gold_map.get(name)
+        if not gold_path:
+            missing.append(name)
+            continue
+
+        tot_pred, pred_b = load_boundaries_from_edus_file(pp)
+        tot_gold, gold_b = load_boundaries_from_edus_file(gold_path)
+        prec, rec, f1, tp, p, g = f1_from_sets(pred_b, gold_b)
+        per_file.append((name, prec, rec, f1, p, g, tp))
+        macro_prec.append(prec)
+        macro_rec.append(rec)
+        macro_f1.append(f1)
+        tp_sum += tp
+        p_sum += p
+        g_sum += g
+
+    if missing:
+        print(f'Missing gold files for {len(missing)} predictions:')
+        for n in missing:
+            print(f'  - {n}')
+
+    if per_file:
+        print('Per-file (name, P, R, F1, |pred|, |gold|, TP):')
+        for name, prec, rec, f1, p, g, tp in per_file:
+            print(f'{name}\tP={prec:.3f}\tR={rec:.3f}\tF1={f1:.3f}\t|pred|={p}\t|gold|={g}\tTP={tp}')
+
+        macro_p = sum(macro_prec)/len(macro_prec)
+        macro_r = sum(macro_rec)/len(macro_rec)
+        macro_f = sum(macro_f1)/len(macro_f1)
+        micro_p = tp_sum / p_sum if p_sum > 0 else 0.0
+        micro_r = tp_sum / g_sum if g_sum > 0 else 0.0
+        micro_f = 0.0 if micro_p + micro_r == 0 else 2*micro_p*micro_r/(micro_p+micro_r)
+
+        print('\nSummary:')
+        print(f'Macro: P={macro_p:.3f}\tR={macro_r:.3f}\tF1={macro_f:.3f}\tN={len(per_file)}')
+        print(f'Micro: P={micro_p:.3f}\tR={micro_r:.3f}\tF1={micro_f:.3f}\tTP={tp_sum}\t|pred|={p_sum}\t|gold|={g_sum}')
+
+
+if __name__ == '__main__':
+    main()

--- a/utils/segment_texts.py
+++ b/utils/segment_texts.py
@@ -1,9 +1,15 @@
 import argparse
 import glob
 import os
+import sys
 from pathlib import Path
 
 import torch
+
+# Ensure repository root is on sys.path when running as a script
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if REPO_ROOT not in sys.path:
+    sys.path.insert(0, REPO_ROOT)
 
 from dmrst_parser.predictor import Predictor
 
@@ -57,40 +63,50 @@ def _subword_to_word_breaks(word_offsets, subword_offsets, subword_breaks):
     return filtered
 
 
-def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0):
+def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0, dump_breaks: bool = False):
     pred = Predictor(model_dir, cuda_device=cuda_device)
     with open(infile, 'r', encoding='utf-8') as f:
-        text = f.read().strip()
+        raw_text = f.read()
 
-    # Basic whitespace tokenization; keep consistent with trainer char-offset logic
-    words = text.split()
-    text_ws = ' '.join(words)
-
-    # Tokenize to subwords
-    toks = pred.tokenizer(text_ws, add_special_tokens=False)
+    # Tokenize to subwords with character offsets on raw text
+    toks = pred.tokenizer(raw_text, add_special_tokens=False, return_offsets_mapping=True)
     input_ids = toks['input_ids']
-    sub_offs = _get_offset_mappings(pred.tokenizer, input_ids)
+    sub_offs = toks['offset_mapping']
     # Predict segmentation
     with torch.no_grad():
         _, _, _, _, pred_edu_breaks = pred.model.testing_loss(
             [input_ids], None, None, None, None, None, None, generate_tree=False, use_pred_segmentation=True)
 
     # pred_edu_breaks is a list with one list of subword indices
-    word_offs = _word_offsets(words)
-    word_breaks = _subword_to_word_breaks(word_offs, sub_offs, pred_edu_breaks[0])
+    sub_breaks = pred_edu_breaks[0]
+    # Map subword breaks to character end positions
+    char_breaks = [max(0, sub_offs[j][1] - 1) for j in sub_breaks]
 
-    # Reconstruct EDUs by word breaks
+    # Reconstruct EDUs by character slices on the original text
     edus = []
-    start = 0
-    for wb in word_breaks:
-        edus.append(' '.join(words[start:wb + 1]))
-        start = wb + 1
+    start_char = 0
+    for ce in char_breaks:
+        # Skip inter-token whitespace at the boundary so segments don't start with a space
+        while start_char < len(raw_text) and raw_text[start_char].isspace() and start_char <= ce:
+            start_char += 1
+        seg = raw_text[start_char:ce + 1]
+        edus.append(seg)
+        start_char = ce + 1
 
     # Write .edus.txt next to outfile
     Path(outdir).mkdir(parents=True, exist_ok=True)
     outpath = Path(outdir) / (Path(infile).stem + '.edus.txt')
     with open(outpath, 'w', encoding='utf-8') as f:
         f.write('\n'.join(edus) + ('\n' if edus else ''))
+    if dump_breaks:
+        import json
+        dbg = {
+            'num_subwords': len(input_ids),
+            'subword_breaks': sub_breaks,
+            'char_breaks': char_breaks,
+        }
+        with open(str(outpath) + '.breaks.json', 'w', encoding='utf-8') as jf:
+            json.dump(dbg, jf, ensure_ascii=False, indent=2)
 
     return str(outpath)
 
@@ -98,21 +114,31 @@ def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0)
 def main():
     ap = argparse.ArgumentParser(description='Segment plain texts into EDUs using a trained model.')
     ap.add_argument('--model_dir', required=True, help='Path to trained run dir (contains config.json, best_weights.pt).')
-    ap.add_argument('--inputs', required=True, help='Glob pattern for input .txt files (e.g., data/*.txt)')
-    ap.add_argument('--out_dir', required=True, help='Output directory for .edus.txt files')
+    ap.add_argument('--input_dir', help='Directory containing input .txt files')
+    ap.add_argument('--output_dir', help='Output directory for .edus.txt files')
+    # Backward-compatible aliases
+    ap.add_argument('--inputs', help='[Deprecated] Glob pattern for input .txt files (e.g., data/*.txt)')
+    ap.add_argument('--out_dir', help='[Deprecated] Output directory for .edus.txt files')
     ap.add_argument('--cuda_device', type=int, default=0)
+    ap.add_argument('--dump_breaks', action='store_true', help='Also write <file>.edus.txt.breaks.json with debug info')
     args = ap.parse_args()
 
-    files = sorted(glob.glob(args.inputs))
+    # Normalize args
+    input_arg = args.input_dir or args.inputs
+    out_dir = args.output_dir or args.out_dir
+    if not input_arg or not out_dir:
+        raise SystemExit('Please provide --input_dir and --output_dir (or legacy --inputs/--out_dir).')
+
+    pattern = os.path.join(input_arg, '*.txt') if os.path.isdir(input_arg) else input_arg
+    files = sorted(glob.glob(pattern))
     if not files:
-        raise SystemExit(f'No files matched: {args.inputs}')
+        raise SystemExit(f'No files matched: {pattern}')
 
     print(f'Segmenting {len(files)} files with model: {args.model_dir}')
     for fp in files:
-        outp = segment_file(args.model_dir, fp, args.out_dir, cuda_device=args.cuda_device)
+        outp = segment_file(args.model_dir, fp, out_dir, cuda_device=args.cuda_device, dump_breaks=args.dump_breaks)
         print(f'Wrote: {outp}')
 
 
 if __name__ == '__main__':
     main()
-

--- a/utils/segment_texts.py
+++ b/utils/segment_texts.py
@@ -2,9 +2,15 @@ import argparse
 import glob
 import os
 import sys
+import warnings
 from pathlib import Path
 
 import torch
+from tqdm import tqdm
+try:
+    from transformers.utils import logging as hf_logging
+except Exception:
+    hf_logging = None
 
 # Ensure repository root is on sys.path when running as a script
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -12,6 +18,11 @@ if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
 from dmrst_parser.predictor import Predictor
+import json as _json
+try:
+    import spacy as _spacy
+except Exception:
+    _spacy = None
 
 
 def _get_offset_mappings(tokenizer, input_ids):
@@ -63,8 +74,46 @@ def _subword_to_word_breaks(word_offsets, subword_offsets, subword_breaks):
     return filtered
 
 
-def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0, dump_breaks: bool = False):
+def _compute_sent_breaks(raw_text: str, subword_offsets):
+    """Compute sentence break flags aligned to subword offsets using spaCy (German).
+
+    Returns a list of length len(subword_offsets) with 0/1 flags marking sentence ends.
+    """
+    if _spacy is None:
+        return None
+    try:
+        nlp = _spacy.load("de_core_news_lg")
+    except Exception:
+        return None
+
+    doc = nlp(raw_text)
+    sent_end_chars = [s.end_char - 1 for s in doc.sents]
+    if not sent_end_chars:
+        return None
+
+    flags = [0] * len(subword_offsets)
+    si = 0
+    for i, (start, end) in enumerate(subword_offsets):
+        if si >= len(sent_end_chars):
+            break
+        # mark break when token end crosses sentence end
+        if end - 1 >= sent_end_chars[si]:
+            flags[i] = 1
+            si += 1
+    # Ensure final token is a break
+    if flags:
+        flags[-1] = 1
+    return flags
+
+
+def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0, dump_breaks: bool = False, quiet: bool = True):
     pred = Predictor(model_dir, cuda_device=cuda_device)
+    # Suppress common harmless warnings if quiet
+    if quiet:
+        try:
+            pred.tokenizer.model_max_length = int(1e9)
+        except Exception:
+            pass
     with open(infile, 'r', encoding='utf-8') as f:
         raw_text = f.read()
 
@@ -72,10 +121,33 @@ def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0,
     toks = pred.tokenizer(raw_text, add_special_tokens=False, return_offsets_mapping=True)
     input_ids = toks['input_ids']
     sub_offs = toks['offset_mapping']
+    # Optionally compute sentence breaks if the model was trained with them and lang is 'de'
+    def _is_true(v):
+        if isinstance(v, bool):
+            return v
+        try:
+            return str(v).lower() in ("1", "true", "yes")
+        except Exception:
+            return False
+
+    use_sent_hints = False
+    try:
+        cfg = _json.load(open(os.path.join(model_dir, 'config.json')))
+        use_sent_hints = _is_true(cfg['model']['segmenter'].get('use_sent_boundaries')) and str(cfg['data'].get('lang')).lower() == 'de'
+    except Exception:
+        pass
+
+    sent_breaks = None
+    if use_sent_hints:
+        flags = _compute_sent_breaks(raw_text, sub_offs)
+        if flags is not None:
+            sent_breaks = [flags]
+
     # Predict segmentation
     with torch.no_grad():
         _, _, _, _, pred_edu_breaks = pred.model.testing_loss(
-            [input_ids], None, None, None, None, None, None, generate_tree=False, use_pred_segmentation=True)
+            [input_ids], sent_breaks, None, None, None, None, None,
+            generate_tree=False, use_pred_segmentation=True)
 
     # pred_edu_breaks is a list with one list of subword indices
     sub_breaks = pred_edu_breaks[0]
@@ -93,20 +165,20 @@ def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0,
         edus.append(seg)
         start_char = ce + 1
 
-    # Write .edus.txt next to outfile
+    # Write _edus.txt next to outfile
     Path(outdir).mkdir(parents=True, exist_ok=True)
-    outpath = Path(outdir) / (Path(infile).stem + '.edus.txt')
+    outpath = Path(outdir) / (Path(infile).stem + '_edus.txt')
     with open(outpath, 'w', encoding='utf-8') as f:
         f.write('\n'.join(edus) + ('\n' if edus else ''))
     if dump_breaks:
-        import json
         dbg = {
             'num_subwords': len(input_ids),
             'subword_breaks': sub_breaks,
             'char_breaks': char_breaks,
+            'used_sentence_hints': bool(sent_breaks is not None)
         }
         with open(str(outpath) + '.breaks.json', 'w', encoding='utf-8') as jf:
-            json.dump(dbg, jf, ensure_ascii=False, indent=2)
+            _json.dump(dbg, jf, ensure_ascii=False, indent=2)
 
     return str(outpath)
 
@@ -115,12 +187,13 @@ def main():
     ap = argparse.ArgumentParser(description='Segment plain texts into EDUs using a trained model.')
     ap.add_argument('--model_dir', required=True, help='Path to trained run dir (contains config.json, best_weights.pt).')
     ap.add_argument('--input_dir', help='Directory containing input .txt files')
-    ap.add_argument('--output_dir', help='Output directory for .edus.txt files')
+    ap.add_argument('--output_dir', help='Output directory for _edus.txt files')
     # Backward-compatible aliases
     ap.add_argument('--inputs', help='[Deprecated] Glob pattern for input .txt files (e.g., data/*.txt)')
     ap.add_argument('--out_dir', help='[Deprecated] Output directory for .edus.txt files')
     ap.add_argument('--cuda_device', type=int, default=0)
     ap.add_argument('--dump_breaks', action='store_true', help='Also write <file>.edus.txt.breaks.json with debug info')
+    ap.add_argument('--verbose', action='store_true', help='Print per-file outputs and show warnings')
     args = ap.parse_args()
 
     # Normalize args
@@ -135,9 +208,20 @@ def main():
         raise SystemExit(f'No files matched: {pattern}')
 
     print(f'Segmenting {len(files)} files with model: {args.model_dir}')
-    for fp in files:
-        outp = segment_file(args.model_dir, fp, out_dir, cuda_device=args.cuda_device, dump_breaks=args.dump_breaks)
-        print(f'Wrote: {outp}')
+
+    # Configure verbosity
+    if not args.verbose:
+        if hf_logging is not None:
+            try:
+                hf_logging.set_verbosity_error()
+            except Exception:
+                pass
+        warnings.filterwarnings("ignore", message="dropout option adds dropout after all but last recurrent layer")
+
+    for fp in tqdm(files, desc='Segmenting', unit='file'):
+        outp = segment_file(args.model_dir, fp, out_dir, cuda_device=args.cuda_device, dump_breaks=args.dump_breaks, quiet=not args.verbose)
+        if args.verbose:
+            tqdm.write(f'Wrote: {outp}')
 
 
 if __name__ == '__main__':

--- a/utils/segment_texts.py
+++ b/utils/segment_texts.py
@@ -1,0 +1,118 @@
+import argparse
+import glob
+import os
+from pathlib import Path
+
+import torch
+
+from dmrst_parser.predictor import Predictor
+
+
+def _get_offset_mappings(tokenizer, input_ids):
+    # Mirror trainer token offset approximation for sentence/EDU mapping
+    subwords_str = tokenizer.convert_ids_to_tokens(input_ids)
+    start, end = 0, 0
+    result = []
+    for subword in subwords_str:
+        if subword.startswith('▁'):
+            if subword != '▁':
+                start += 1
+        if subword == '<P>' and start > 0:
+            start += 1
+            end += 1
+        end += len(subword)
+        result.append((start, end))
+        start = end
+    return result
+
+
+def _word_offsets(words):
+    offs = []
+    cur = 0
+    for w in words:
+        offs.append((cur, cur + len(w)))
+        cur += len(w) + 1
+    return offs
+
+
+def _subword_to_word_breaks(word_offsets, subword_offsets, subword_breaks):
+    # Map each predicted subword break j to the largest word index whose end <= subword_offsets[j].end-1
+    result = []
+    for j in subword_breaks:
+        sw_end = subword_offsets[j][1] - 1
+        wi = 0
+        for idx, (_, w_end) in enumerate(word_offsets):
+            if w_end - 1 <= sw_end:
+                wi = idx
+            else:
+                break
+        result.append(wi)
+    # Ensure strictly increasing indices
+    filtered = []
+    last = -1
+    for wi in result:
+        if wi > last:
+            filtered.append(wi)
+            last = wi
+    return filtered
+
+
+def segment_file(model_dir: str, infile: str, outdir: str, cuda_device: int = 0):
+    pred = Predictor(model_dir, cuda_device=cuda_device)
+    with open(infile, 'r', encoding='utf-8') as f:
+        text = f.read().strip()
+
+    # Basic whitespace tokenization; keep consistent with trainer char-offset logic
+    words = text.split()
+    text_ws = ' '.join(words)
+
+    # Tokenize to subwords
+    toks = pred.tokenizer(text_ws, add_special_tokens=False)
+    input_ids = toks['input_ids']
+    sub_offs = _get_offset_mappings(pred.tokenizer, input_ids)
+    # Predict segmentation
+    with torch.no_grad():
+        _, _, _, _, pred_edu_breaks = pred.model.testing_loss(
+            [input_ids], None, None, None, None, None, None, generate_tree=False, use_pred_segmentation=True)
+
+    # pred_edu_breaks is a list with one list of subword indices
+    word_offs = _word_offsets(words)
+    word_breaks = _subword_to_word_breaks(word_offs, sub_offs, pred_edu_breaks[0])
+
+    # Reconstruct EDUs by word breaks
+    edus = []
+    start = 0
+    for wb in word_breaks:
+        edus.append(' '.join(words[start:wb + 1]))
+        start = wb + 1
+
+    # Write .edus.txt next to outfile
+    Path(outdir).mkdir(parents=True, exist_ok=True)
+    outpath = Path(outdir) / (Path(infile).stem + '.edus.txt')
+    with open(outpath, 'w', encoding='utf-8') as f:
+        f.write('\n'.join(edus) + ('\n' if edus else ''))
+
+    return str(outpath)
+
+
+def main():
+    ap = argparse.ArgumentParser(description='Segment plain texts into EDUs using a trained model.')
+    ap.add_argument('--model_dir', required=True, help='Path to trained run dir (contains config.json, best_weights.pt).')
+    ap.add_argument('--inputs', required=True, help='Glob pattern for input .txt files (e.g., data/*.txt)')
+    ap.add_argument('--out_dir', required=True, help='Output directory for .edus.txt files')
+    ap.add_argument('--cuda_device', type=int, default=0)
+    args = ap.parse_args()
+
+    files = sorted(glob.glob(args.inputs))
+    if not files:
+        raise SystemExit(f'No files matched: {args.inputs}')
+
+    print(f'Segmenting {len(files)} files with model: {args.model_dir}')
+    for fp in files:
+        outp = segment_file(args.model_dir, fp, args.out_dir, cuda_device=args.cuda_device)
+        print(f'Wrote: {outp}')
+
+
+if __name__ == '__main__':
+    main()
+


### PR DESCRIPTION
- add EDU segmentation pipeline from plain text:
  - `utils/segment_texts.py` converts `.txt` → `<name>_edus.txt` (one EDU per line), optional `--dump_breaks` for debugging
  - works with any saved run dir (`config.json` + `best_weights.pt`)
- add segmentation evaluation with persistable results:
  - `utils/eval_segmentation.py` computes token-boundary P/R/F1 (per-file + macro/micro)
- documented end-to-end usage in README_DEMIX.md:
  - segmentation and evaluation commands, JSON result location, and final selected checkpoint
- outcome:
  - final segmentation reference: `saves/de_DE-MIX_default+base_linear_hints_40` (Macro 0.776 / Micro 0.744 on 33-doc test slice)